### PR TITLE
Règlement modifiant le Règlement sur l’enseignement à la maison

### DIFF
--- a/I-13.3, r. 6.01 - Règlement sur l’enseignement à la maison.md
+++ b/I-13.3, r. 6.01 - Règlement sur l’enseignement à la maison.md
@@ -31,13 +31,12 @@ D. 644-2018, sec. III.
 § 1.  — Forme et contenu du projet d’apprentissage
 D. 644-2018, ss. 1.
 
-4. Le projet d’apprentissage de l’enfant doit:
-1°  soit prévoir l’application des programmes d’études établis par le ministre en vertu de l’article 461 de la Loi, comporter les activités ou contenus prescrits par le ministre dans les domaines généraux de formation qu’il établit en vertu de ce dernier article de même que prévoir la passation des épreuves imposées par le ministre en vertu du premier alinéa de l’article 463 de la Loi et par la commission scolaire compétente en vertu du deuxième alinéa de l’article 231 de la Loi, selon ce qui serait compris dans les services éducatifs qui seraient dispensés à l’enfant s’il fréquentait une école;
-2°  soit autrement comporter des activités variées et stimulantes visant l’acquisition d’un ensemble de connaissances et de compétences, incluant l’apprentissage de la langue française, d’une autre langue et de la mathématique ainsi que d’au moins une matière ou discipline appartenant à chacun des domaines d’apprentissage suivants:
-a)  mathématique, science et technologie;
-b)  arts;
-c)  développement de la personne;
-d)  dans le cas où l’enfant a atteint l’âge de 9 ans à la date du début de la mise en oeuvre du projet d’apprentissage, univers social.
+Le projet d’apprentissage de l’enfant doit:
+1° soit prévoir l’application de tout programme d’études établi par le ministre en vertu du premier alinéa de l’article 461 de la Loi, comporter les activités ou contenus prescrits par le ministre dans les domaines généraux de formation qu’il établit en vertu du troisième alinéa de ce dernier article de même que prévoir la passation des épreuves imposées par la commission scolaire compétente en vertu du deuxième alinéa de l’article 231 de la Loi, selon ce qui serait compris dans les services éducatifs qui seraient dispensés à l’enfant s’il fréquentait une école;
+2° soit autrement viser l’acquisition d’un ensemble de connaissances et de compétences diverses et, à cette fin, notamment prévoir des activités variées et stimulantes ainsi que l’application des programmes d’études établis par le ministre en vertu du premier alinéa de l’article 461 de la Loi pour les services d’enseignement primaire et secondaire dans les matières suivantes:
+a) une matière visant la langue d’enseignement et une matière visant la langue seconde, selon le choix des parents, l’une en français et l’autre en anglais;
+b) les matières obligatoires du domaine de la mathématique, de la science et de la technologie et du domaine de l’univers social, choisies parmi celles qui sont enseignées au cours du cycle d’enseignement dans lequel serait l’enfant s’il fréquentait l’école.
+Pour l’application du paragraphe 2° du premier alinéa, un contenu visant l’atteinte des objectifs compris au programme de chaque matière doit être enseigné de façon à permettre une progression des apprentissages équivalente à celle applicable par cycle à l’école.
 D. 644-2018, a. 4.
 
 5. Les parents doivent transmettre au ministre un document décrivant le projet d’apprentissage de l’enfant au plus tard:
@@ -45,7 +44,7 @@ D. 644-2018, a. 4.
 2°  dans le cas où l’enfant cesse de fréquenter un établissement d’enseignement au cours d’une année scolaire, dans les 30 jours de la date de cette cessation.
 Ce document indique notamment les éléments suivants:
 1°  une description de l’approche éducative choisie;
-2°  une description sommaire des activités choisies relativement à l’apprentissage de la langue française, d’une autre langue et de la mathématique;
+2°  les programmes d’études visés ainsi qu’une description sommaire des activités choisies relativement à ceux-ci;
 3°  les autres matières ou disciplines qui seront enseignées ainsi qu’une description sommaire des activités choisies à cette fin;
 4°  les autres connaissances et compétences dont l’acquisition est visée ainsi qu’une description sommaire des activités choisies à cette fin;
 5°  les ressources éducatives qui seront utilisées;
@@ -82,14 +81,14 @@ Cet état de situation indique les activités d’apprentissage réalisées par 
 Malgré le premier alinéa, dans le cas où l’enfant cesse de fréquenter un établissement d’enseignement entre le 1er janvier et le 31 mars, l’état de situation doit être transmis au plus tard le 15 juin suivant le début de la mise en oeuvre du projet d’apprentissage. Dans le cas où l’enfant cesse de fréquenter un tel établissement après le 31 mars, l’état de situation est facultatif.
 D. 644-2018, a. 11.
 
-12. Les parents participent à une rencontre de suivi au cours de la mise en oeuvre du projet d’apprentissage de l’enfant. Ils peuvent être accompagnés par la personne de leur choix lors de cette rencontre.
+12. Les parents et l'enfant participent à une rencontre de suivi au cours de la mise en oeuvre du projet d’apprentissage de l’enfant. Ils peuvent être accompagnés par la personne de leur choix lors de cette rencontre.
 Une telle rencontre peut être tenue à l’aide de tout moyen permettant aux participants de communiquer immédiatement entre eux.
 Le ministre avise par écrit les parents du moment et des modalités de cette rencontre au moins 15 jours avant sa tenue.
 D. 644-2018, a. 12.
 § 3.  — Difficulté liée à la mise en oeuvre du projet d’apprentissage
 D. 644-2018, ss. 3.
 
-13. En cas de difficulté liée à la mise en oeuvre du projet d’apprentissage de l’enfant, les parents participent à une rencontre visant à y remédier. Ils peuvent être accompagnés par la personne de leur choix lors de cette rencontre.
+13. En cas de difficulté liée à la mise en oeuvre du projet d’apprentissage de l’enfant, les parents et l'enfant participent à une rencontre visant à y remédier. Ils peuvent être accompagnés par la personne de leur choix lors de cette rencontre.
 Une telle rencontre peut être tenue à l’aide de tout moyen permettant aux participants de communiquer immédiatement entre eux.
 Le ministre avise par écrit les parents du moment et des modalités de cette rencontre au moins 15 jours avant sa tenue.
 D. 644-2018, a. 13.
@@ -108,6 +107,9 @@ D. 644-2018, sec. IV.
 5°  un portfolio soumis au ministre.
 Les paragraphes 1 à 3 du premier alinéa ne doivent pas être interprétés comme restreignant les modes d’évaluation à ceux qui sont généralement utilisés dans le milieu scolaire telle une évaluation sommative.
 D. 644-2018, a. 15.
+
+15.1. En outre des évaluations choisies par les parents pour évaluer la progression des apprentissages de leur enfant, ce dernier doit se soumettre à toute épreuve imposée par le ministre en vertu du premier alinéa de l’article 463 de la Loi, au plus tard au terme du projet d’apprentissage lors duquel le contenu visant l’atteinte des objectifs compris au programme de la matière faisant l’objet de l’épreuve devra avoir été enseigné.
+Le ministre peut dispenser un enfant de la passation d’une épreuve visée au premier alinéa si celui-ci est dans l’impossibilité de se présenter à la séance tenue à cette fin en raison d’une maladie ou d’autres circonstances exceptionnelles.
 
 16. Les parents dressent 2 bilans écrits de la progression de l’enfant et les transmettent au ministre aux moments suivants:
 1°  un bilan de mi-parcours entre le troisième et le cinquième mois suivant le début de la mise en oeuvre du projet d’apprentissage;
@@ -152,9 +154,12 @@ D. 644-2018, a. 22.
 23. La commission scolaire prend les mesures nécessaires pour permettre à l’enfant qui reçoit un enseignement à la maison d’être candidat à toute épreuve qu’elle impose en vertu du deuxième alinéa de l’article 231 de la Loi.
 Elle prend également les mesures nécessaires pour que l’enfant qui reçoit un enseignement à la maison et qui peut être candidat à une épreuve imposée par le ministre en vertu du premier alinéa de l’article 463 de la Loi puisse se présenter à une séance tenue à cette fin dans un de ses locaux.
 La passation de ces épreuves et les activités préparatoires à celle-ci sont gratuites.
+Rien dans le présent article n’empêche le ministre de tenir une séance permettant la passation d’une épreuve visée au deuxième alinéa.
 D. 644-2018, a. 23.
 
-24. Les parents qui font une demande en application des dispositions de l’article 20 ou de l’article 21 doivent fournir à la commission scolaire compétente le projet d’apprentissage de l’enfant.
+23.1. La commission scolaire prend les mesures nécessaires pour permettre à l’enfant qui reçoit un enseignement à la maison d’être évalué en vue de l’obtention d’unités requises pour la délivrance d’un diplôme reconnu par le ministre, sans qu’il ait suivi le cours correspondant, en tenant compte des exigences pédagogiques et organisationnelles.
+
+24. Les parents qui font une demande en application des dispositions de l’article 20, 21 ou 23.1 doivent fournir à la commission scolaire compétente le projet d’apprentissage de l’enfant.
 D. 644-2018, a. 24.
 SECTION VI
 DISPOSITIONS TRANSITOIRE ET FINALE

--- a/I-13.3, r. 6.01 - Règlement sur l’enseignement à la maison.md
+++ b/I-13.3, r. 6.01 - Règlement sur l’enseignement à la maison.md
@@ -28,7 +28,7 @@ PROJET D’APPRENTISSAGE
 
 § 1.  — Forme et contenu du projet d’apprentissage
 
-Le projet d’apprentissage de l’enfant doit:
+4. Le projet d’apprentissage de l’enfant doit:
 1° soit prévoir l’application de tout programme d’études établi par le ministre en vertu du premier alinéa de l’article 461 de la Loi, comporter les activités ou contenus prescrits par le ministre dans les domaines généraux de formation qu’il établit en vertu du troisième alinéa de ce dernier article de même que prévoir la passation des épreuves imposées par la commission scolaire compétente en vertu du deuxième alinéa de l’article 231 de la Loi, selon ce qui serait compris dans les services éducatifs qui seraient dispensés à l’enfant s’il fréquentait une école;
 2° soit autrement viser l’acquisition d’un ensemble de connaissances et de compétences diverses et, à cette fin, notamment prévoir des activités variées et stimulantes ainsi que l’application des programmes d’études établis par le ministre en vertu du premier alinéa de l’article 461 de la Loi pour les services d’enseignement primaire et secondaire dans les matières suivantes:
 a) une matière visant la langue d’enseignement et une matière visant la langue seconde, selon le choix des parents, l’une en français et l’autre en anglais;


### PR DESCRIPTION
Avis est donné par les présentes, conformément aux articles 10 et 11 de la Loi sur les règlements (chapitre R-18.1), que le projet de règlement modifiant le Règlement sur l’enseignement à la maison, dont le texte apparaît ci-dessous, pourra être édicté par le gouvernement à l’expiration d’un délai de 45 jours à compter de la présente publication.

Ce projet de règlement vise à modifier certaines conditions et modalités qui doivent être remplies pour qu’un enfant soit dispensé de l’obligation de fréquenter une école aux fins de recevoir un enseignement à la maison. Il revoit notamment les exigences liées au contenu minimal du projet d’apprentissage de l’enfant qui reçoit un tel enseignement et établit certaines normes relatives à l’évaluation de la progression de ses apprentissages.

Ce projet de règlement n’a pas de répercussion sur les entreprises, en particulier sur les PME.

Des renseignements additionnels concernant ce projet de règlement peuvent être obtenus en s’adressant à madame Stéphanie Vachon, Secrétaire générale, ministère de l’Éducation et de l’Enseignement supérieur, 1035, rue De La Chevrotière, 15e étage, Québec (Québec) G1R 5A5;
téléphone : 418 643-3810, poste 3927; courriel: stephanie.vachon@education.gouv.qc.ca.

Toute personne ayant des commentaires à formuler à ce sujet est priée de les faire parvenir par écrit, avant l’expiration du délai de 45 jours mentionné ci-dessus, au ministre de l’Éducation et de l’Enseignement supérieur, 1035, rue De La Chevrotière, 16e étage, Québec (Québec) G1R 5A5.